### PR TITLE
HT-3304 ht_users should join on inst_id, not entityID

### DIFF
--- a/sql/000_ht_schema.sql
+++ b/sql/000_ht_schema.sql
@@ -175,7 +175,8 @@ CREATE TABLE `ht_users` (
   `expire_type` varchar(32) DEFAULT NULL,
   `iprestrict` varchar(1024) DEFAULT NULL,
   `mfa` tinyint(1) DEFAULT NULL,
-  `identity_provider` varchar(255) DEFAULT NULL
+  `identity_provider` varchar(255) DEFAULT NULL,
+  `inst_id` varchar(64) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 


### PR DESCRIPTION
- Using the same `VARCHAR` size used by `ht_institutions.inst_id`
- `ht_users.identity_provider` left intact for now