### PR TITLE
ht_institutions schema update

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Clone latest repository
       uses: actions/checkout@v2
-    - name: Build container image and push to DockerHub
+    - name: Build container image and push to GHCR
       id: docker_build
       uses: docker/build-push-action@v2
       with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 ## db-image
 
 Docker image with MariaDB and HathiTrust database for testing.
+
+Note: the `mdp-lib` credentials (at the end of `sql/000_ht_schema.sql`)
+should be used wherever possible. The `mdp-admin` account has write
+permission and can be used for seeding the database where necessary.
+
+*Under no circumstances should this image be used in a production
+environment!*

--- a/sql/000_ht_schema.sql
+++ b/sql/000_ht_schema.sql
@@ -103,20 +103,21 @@ DROP TABLE IF EXISTS `ht_institutions`;
 CREATE TABLE `ht_institutions` (
   `inst_id` varchar(64) DEFAULT NULL,
   `grin_instance` varchar(8) DEFAULT NULL,
-  `name` varchar(256) NOT NULL,
-  `template` varchar(256) NOT NULL,
-  `domain` varchar(32) NOT NULL,
-  `us` tinyint(1) NOT NULL,
+  `name` varchar(256) DEFAULT NULL,
+  `template` varchar(256) DEFAULT NULL,
+  `domain` varchar(32) DEFAULT NULL,
+  `us` tinyint(1) NOT NULL DEFAULT 0,
   `mapto_inst_id` varchar(32) DEFAULT NULL,
   `mapto_name` varchar(256) DEFAULT NULL,
-  `enabled` tinyint(1) NOT NULL,
+  `enabled` tinyint(1) NOT NULL DEFAULT 0,
   `entityID` varchar(256) DEFAULT NULL,
-  `allowed_affiliations` text,
+  `allowed_affiliations` text DEFAULT NULL,
   `shib_authncontext_class` varchar(255) DEFAULT NULL,
-  `emergency_status` text,
-  `emergency_contact` varchar(255) DEFAULT NULL,
-  `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+  `emergency_status` text DEFAULT NULL,
+  `last_update` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  KEY `ht_institutions_inst_id` (`inst_id`),
+  KEY `ht_institutions_mapto_inst_id` (`mapto_inst_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 DROP TABLE IF EXISTS `ht_namespaces`;
@@ -277,3 +278,4 @@ CREATE TABLE `sources` (
 
 
 GRANT SELECT ON `ht`.* TO 'mdp-lib'@'%' IDENTIFIED BY 'mdp-lib';
+GRANT ALL ON `ht`.* TO 'mdp-admin'@'%' IDENTIFIED BY 'mdp-admin';

--- a/sql/013_ht_institutions.sql
+++ b/sql/013_ht_institutions.sql
@@ -1,5 +1,21 @@
 USE ht;
 LOCK TABLES `ht_institutions` WRITE;
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+
+LOCK TABLES `ht_institutions` WRITE;
+/*!40000 ALTER TABLE `ht_institutions` DISABLE KEYS */;
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('abac', 'Abraham Baldwin Agricultural College', '', 'abac.edu', 1, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('allegheny', 'Allegheny College', '', 'allegheny.edu', 1, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('amherst', 'Amherst College', '', 'amherst.edu', 1, 1);
@@ -322,4 +338,15 @@ INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VAL
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('pratt', 'Pratt Institute', '', 'pratt.edu', 1, 0);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('wits', 'University of the Witwatersrand, Johannesburg', '', 'wits.ac.za', 0, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('aucegypt', 'The American University in Cairo', '', 'aucegypt.edu', 0, 0);
+/*!40000 ALTER TABLE `ht_institutions` ENABLE KEYS */;
 UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+

--- a/sql/013_ht_institutions.sql
+++ b/sql/013_ht_institutions.sql
@@ -162,7 +162,7 @@ INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VAL
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('ptsem', 'Princeton Theological Seminary', '', 'ptsem.edu', 1, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('pugetsound', 'University of Puget Sound', '', 'pugetsound.edu', 1, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('purdue', 'Purdue University', '', 'purdue.edu', 1, 1);
-INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('queensu', 'Queen's University', '', 'queensu.ca', 0, 1);
+INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('queensu', "Queen's University", '', 'queensu.ca', 0, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('reed', 'Reed College', '', 'reed.edu', 1, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('richmond', 'University of Richmond', '', 'richmond.edu', 1, 1);
 INSERT INTO `ht_institutions` (inst_id, name, template, domain, us, enabled) VALUES ('rochester', 'University of Rochester', '', 'rochester.edu', 1, 1);


### PR DESCRIPTION
- Address drift in ht_institutions defaults and encoding..
- Fix reference to Dockerhub in GHCR action.
- Fix single quote in `queensu` entry in `013_ht_institutions.sql`.
- Add mdp-admin credentials and README warning.