### PR TITLE
DEV-1516 rename oclc concordance fields

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+---
 
 services:
   mariadb:

--- a/sql/000_ht_schema.sql
+++ b/sql/000_ht_schema.sql
@@ -320,9 +320,9 @@ CREATE TABLE `sources` (
 
 DROP TABLE IF EXISTS `oclc_concordance`;
 CREATE TABLE `oclc_concordance` (
-  `oclc` int(10) unsigned NOT NULL,
+  `variant` int(10) unsigned NOT NULL,
   `canonical` int(10) unsigned DEFAULT NULL,
-  KEY `oclc_c_oclc` (`oclc`),
+  KEY `oclc_c_var` (`variant`),
   KEY `oclc_c_canon` (`canonical`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 


### PR DESCRIPTION
- Update `oclc_concordance.oclc` to `oclc_concordance.variant`.
- Tidy: remove deprecated version from docker-compose.yml

Reviewer: just a spot check?
