### PR TITLE
Fix Failing `Docker Tag Latest Release` Action

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,3 +1,4 @@
+---
 name: Docker Tag Latest Release
 
 on:
@@ -11,6 +12,6 @@ jobs:
       - uses: hathitrust/github_actions/tag-release@v1
         with:
           registry_token: ${{ github.token }}
-          existing_tag: ghcr.io/${{ github.repository }}-unstable:${{ github.sha }}
+          existing_tag: ghcr.io/${{ github.repository }}:${{ github.sha }}
           image: ghcr.io/${{ github.repository }}
           new_tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
- Remove `-unstable` suffix on `existing_tag` to keep action from failing after many retries.