### PR TITLE
Fix collation on ht_institutions schema

### DIFF
--- a/sql/000_ht_schema.sql
+++ b/sql/000_ht_schema.sql
@@ -142,7 +142,7 @@ CREATE TABLE `ht_institutions` (
   `last_update` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   KEY `ht_institutions_inst_id` (`inst_id`),
   KEY `ht_institutions_mapto_inst_id` (`mapto_inst_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 DROP TABLE IF EXISTS `ht_namespaces`;


### PR DESCRIPTION
- Originally unset, add `utf8_general_ci` to be joinable with `holdings_htitem_htmember` in the catalog indexer.