### PR TITLE
Update default platforms in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
             platforms:
                 description: Platforms to build for
                 type: choice
-                default: linux/amd64
+                default: linux/amd64,linux/arm64
                 options:
                 - linux/amd64,linux/arm64
                 - linux/amd64


### PR DESCRIPTION
Some images should build both by default. This is one of them.