### PR TITLE
Maintenance update for April 2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM mariadb:10.5
-ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+FROM mariadb:11.8
+ENV MARIADB_RANDOM_ROOT_PASSWORD=1
 ADD sql/*.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
- Use mariadb 11.8 to track Debian 13
- Update `MYSQL_RANDOM_ROOT_PASSWORD` to `MARIADB_RANDOM_ROOT_PASSWORD`

Built and tested with modified `babel` docker-compose.