### PR TITLE
Mariadb 12.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Run Tests
               run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM mariadb:12.3
-ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+ENV MARIADB_RANDOM_ROOT_PASSWORD=1
 ADD sql/*.sql /docker-entrypoint-initdb.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM mariadb:10.5
+FROM mariadb:12.3
 ENV MYSQL_RANDOM_ROOT_PASSWORD=1
 ADD sql/*.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
* Updates mariadb to the version we are using in production
* MYSQL -> MARIADB (see https://github.com/hathitrust/db-image/pull/32)